### PR TITLE
List replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Example body of the call:
 Server returns:
 
 ```json
+
 {
     "id": 4,
     "comment": "A comment for a thread",
@@ -141,4 +142,44 @@ Server returns:
         }
     }
 }
+```
+
+**GET replies for a thread**
+
+Endpoint: `/threads/{threadId}/replies`
+
+Example URL: `http://localhost:8080/web-forum/api/threads/67/replies`
+
+Server returns:
+
+```json
+
+[
+    {
+        "id": 2,
+        "comment": "This is a comment of the reply",
+        "thread": {
+            "id": 67,
+            "title": "This a title for a thread",
+            "content": "Content of the thread",
+            "category": {
+                "id": 3,
+                "title": "Video Games"
+            }
+        }
+    },
+    {
+        "id": 3,
+        "comment": "Another comment of a reply",
+        "thread": {
+            "id": 67,
+            "title": "This a title for a thread",
+            "content": "Content of the thread",
+            "category": {
+                "id": 3,
+                "title": "Video Games"
+            }
+        }
+    }
+]
 ```

--- a/src/main/java/forum/dao/ReplyDAO.java
+++ b/src/main/java/forum/dao/ReplyDAO.java
@@ -1,5 +1,7 @@
 package forum.dao;
 
+import java.util.List;
+
 import forum.entity.Reply;
 
 public interface ReplyDAO {
@@ -7,5 +9,7 @@ public interface ReplyDAO {
 	public int saveReply(Reply reply);
 	
 	public Reply getReply(int id);
+	
+	public List<Reply> getRepliesForThread(int threadId);
 
 }

--- a/src/main/java/forum/dao/ReplyDAOImpl.java
+++ b/src/main/java/forum/dao/ReplyDAOImpl.java
@@ -1,7 +1,10 @@
 package forum.dao;
 
+import java.util.List;
+
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
@@ -33,4 +36,18 @@ public class ReplyDAOImpl implements ReplyDAO {
 		return reply;
 	}
 
+	@Override
+	public List<Reply> getRepliesForThread(int threadId) {
+		
+		Session currentSession = sessionFactory.getCurrentSession();
+		
+		Query<Reply> theQuery = currentSession.createQuery("from Reply where thread_id=:threadId", Reply.class);
+		
+		theQuery.setParameter("threadId", threadId);
+		
+		List<Reply> replies = theQuery.getResultList();
+
+		return replies;
+	}
+	
 }

--- a/src/main/java/forum/rest/ReplyRestController.java
+++ b/src/main/java/forum/rest/ReplyRestController.java
@@ -1,8 +1,11 @@
 package forum.rest;
 
+import java.util.List;
+
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,5 +44,17 @@ public class ReplyRestController {
 		
 	}
 	
+	@GetMapping("/threads/{threadId}/replies")
+	public List<Reply> getRepliesForThread(@PathVariable int threadId) {
+		
+		Thread thread = threadService.getThread(threadId);
+
+		if (thread == null) {
+			throw new ForumItemNotFoundException("Thread id not found - " + threadId);
+		}
+		
+		return replyService.getRepliesForThread(threadId);
+		
+	}
 
 }

--- a/src/main/java/forum/service/ReplyService.java
+++ b/src/main/java/forum/service/ReplyService.java
@@ -1,9 +1,13 @@
 package forum.service;
 
+import java.util.List;
+
 import forum.entity.Reply;
 
 public interface ReplyService {
 	
 	public Reply saveReply(Reply reply);
+	
+	public List<Reply> getRepliesForThread(int threadId);
 
 }

--- a/src/main/java/forum/service/ReplyServiceImpl.java
+++ b/src/main/java/forum/service/ReplyServiceImpl.java
@@ -1,5 +1,7 @@
 package forum.service;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +24,13 @@ public class ReplyServiceImpl implements ReplyService {
 		Reply savedReply = replyDAO.getReply(replyId);
 		
 		return savedReply;
+	}
+
+	@Override
+	@Transactional
+	public List<Reply> getRepliesForThread(int threadId) {
+
+		return replyDAO.getRepliesForThread(threadId);
 	}
 
 }


### PR DESCRIPTION
Fixes #11 

Added GET method for the endpoint `/threads/{threadId}/replies`

Lists replies for a given thread

URL example: `http://localhost:8080/web-forum/api/threads/67/replies`

Server returns: 

```json

[
    {
        "id": 2,
        "comment": "This is a comment of the reply",
        "thread": {
            "id": 67,
            "title": "This a title for a thread",
            "content": "Content of the thread",
            "category": {
                "id": 3,
                "title": "Video Games"
            }
        }
    },
    {
        "id": 3,
        "comment": "Another comment of a reply",
        "thread": {
            "id": 67,
            "title": "This a title for a thread",
            "content": "Content of the thread",
            "category": {
                "id": 3,
                "title": "Video Games"
            }
        }
    }
]
```

Example of exception:

Faulty URL: `http://localhost:8080/web-forum/api/threads/555/replies`

There is no thread that has an id of 555.

Server returns:

```json
{
    "status": 404,
    "message": "Thread id not found - 555",
    "timeStamp": 1549357149316
}
```